### PR TITLE
fix: Android API 36に対応

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,22 +12,25 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: install java 19.x
-        uses: actions/setup-java@v3
+      - name: install java 17.x
+        uses: actions/setup-java@v4
         with:
-          java-version: '19'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: install flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.32.2'
+          flutter-version: '3.47.0'
           channel: 'stable'
 
+      - name: install Android 16 SDK
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
       - name: cache flutter dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pub-cache
@@ -36,10 +39,9 @@ jobs:
             ${{ runner.os }}-flutter-
 
       - name: setup env file
-        if: env.BASE64_ENV_FILE != ''
         env:
           BASE64_ENV_FILE: ${{ secrets.BASE64_ENV_FILE }}
-        run: echo $BASE64_ENV_FILE | base64 --decode > .env
+        run: echo "$BASE64_ENV_FILE" | base64 --decode > .env
 
       - name: flutter dependencies install
         run: flutter pub get
@@ -47,10 +49,9 @@ jobs:
       - run: flutter test
 
       - name: decode keystore
-        if: env.ENCODED_DEBUG_KEYSTORE != ''
         env:
           ENCODED_DEBUG_KEYSTORE: ${{ secrets.ENCODED_DEBUG_KEYSTORE }}
-        run: echo $ENCODED_DEBUG_KEYSTORE | base64 --decode > ~/.android/debug.keystore
+        run: echo "$ENCODED_DEBUG_KEYSTORE" | base64 --decode > ~/.android/debug.keystore
 
       - name: build apk
         run: flutter build apk --flavor beta
@@ -64,7 +65,7 @@ jobs:
           curl \
             -H "Authorization: token $DEPLOYGATE_API_KEY" \
             -F "file=@build/app/outputs/flutter-apk/app-beta-release.apk" \
-            -F "message=git:`git rev-parse --short $GITHUB_SHA`" \
+            -F "message=git:$(git rev-parse --short "$GITHUB_SHA")" \
             -F "distribution_name=${{ github.ref_name }}" \
             -F "release_note=new build" \
             -F "distribution_key=$ANDROID_DISTRIBUTION_HASH" \

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,6 +58,13 @@ jobs:
       - name: build apk
         run: flutter build apk --flavor beta
 
+      - name: upload apk artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: presc-beta-apk
+          path: build/app/outputs/flutter-apk/app-beta-release.apk
+          retention-days: 7
+
       - name: distribute android apk
         env:
           DEPLOYGATE_API_KEY: ${{ secrets.DEPLOYGATE_API_KEY }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install java 17.x
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -27,10 +27,12 @@ jobs:
           channel: 'stable'
 
       - name: install Android 16 SDK
-        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+        run: |
+          sdkmanager_path=$(find "$HOME/Library/Android/sdk/cmdline-tools" -type f -name sdkmanager -print -quit)
+          "$sdkmanager_path" "platforms;android-36" "build-tools;36.0.0"
 
       - name: cache flutter dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,7 +42,7 @@ android {
 
     defaultConfig {
         applicationId "com.sakusaku3939.presc"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     flavorDimensions "default"
     namespace "com.sakusaku3939.presc"
 
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         applicationId "com.sakusaku3939.presc"
         minSdkVersion 23
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
 
    <application
         android:label="Presc"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.4.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/lib/features/manuscript/ui/pages/manuscript_edit_page.dart
+++ b/lib/features/manuscript/ui/pages/manuscript_edit_page.dart
@@ -28,10 +28,11 @@ class ManuscriptEditPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     _edit.init(context, index);
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
         await _edit.back(this.context);
-        return Future.value(false);
       },
       child: Scaffold(
         backgroundColor: Colors.transparent,

--- a/lib/features/manuscript/ui/pages/manuscript_filter_page.dart
+++ b/lib/features/manuscript/ui/pages/manuscript_filter_page.dart
@@ -24,10 +24,11 @@ class ManuscriptFilterPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
         _back(context);
-        return Future.value(false);
       },
       child: Scaffold(
         appBar: _appbar(context),

--- a/lib/features/manuscript/ui/pages/manuscript_search_page.dart
+++ b/lib/features/manuscript/ui/pages/manuscript_search_page.dart
@@ -17,10 +17,11 @@ class ManuscriptSearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
         _back(context);
-        return Future.value(false);
       },
       child: KeyboardDismissOnTap(
         child: Scaffold(

--- a/lib/features/playback/ui/pages/playback_page.dart
+++ b/lib/features/playback/ui/pages/playback_page.dart
@@ -21,11 +21,12 @@ class PlaybackPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final playbackTextView = PlaybackTextView(content);
-    return WillPopScope(
-      onWillPop: () {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
         final speech = context.read<SpeechToTextProvider>();
         speech.back(context);
-        return Future.value(false);
       },
       child: Consumer<PlaybackProvider>(
         builder: (context, model, child) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -409,10 +409,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   intl_utils:
     dependency: "direct dev"
     description:
@@ -433,50 +433,50 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -830,10 +830,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -926,10 +926,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.4.2"
   vibration:
     dependency: "direct main"
     description:
@@ -1019,5 +1019,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
## 概要

Android API 36を対象に、Flutter/Androidビルド環境と戻る操作を更新しました。

## 変更内容

- `compileSdk` / `targetSdk`を36、`minSdk`をFlutter 3.47の実効要件である24へ更新
- Flutter 3.47、Java 17、AGP 8.11.1、Gradle 8.14、Kotlin 2.2.20へ更新
- Predictive Back対応としてManifest設定を有効化し、`WillPopScope`を`PopScope`へ移行
- GitHub Actionsを現行Actionへ更新し、Android 16 SDK導入とGradleヒープ設定を追加
- beta APKを7日間のGitHub Actions Artifactとして保存し、DeployGateへ配布

## 確認内容

- `flutter test` 成功
- 変更した4つのDartファイルをFlutter 3.47で解析し、エラーなし（既存の`share_plus`非推奨info 2件のみ）
- `actionlint .github/workflows/android.yml` 成功
- API 36 release APKの生成、Artifact保存、DeployGateアップロード成功
- APK解析で`compileSdk 36`、`targetSdk 36`、`minSdk 24`を確認
- Android CLIでAPI 36エミュレーターへインストールし、ホーム、検索、編集、再生、戻る操作を確認
- Android端末ログにFatal crashなし

## CI

https://github.com/sakusaku3939/Presc/actions/runs/32978451056
