### PR TITLE
fix: 原稿入力位置とiOS共有を修正

### DIFF
--- a/lib/features/manuscript/ui/pages/manuscript_edit_page.dart
+++ b/lib/features/manuscript/ui/pages/manuscript_edit_page.dart
@@ -99,7 +99,7 @@ class ManuscriptEditPage extends StatelessWidget {
             size: 32,
             onPressed: () async => await _edit.back(this.context),
           ),
-          _edit.isEditable ? _editStateMenu() : _trashStateMenu()
+          _edit.isEditable ? _editStateMenu(context) : _trashStateMenu()
         ],
       ),
     );
@@ -122,7 +122,6 @@ class ManuscriptEditPage extends StatelessWidget {
             ),
             keyboardType: TextInputType.text,
             textInputAction: TextInputAction.go,
-            autofocus: autofocus,
             maxLines: null,
             decoration: InputDecoration(
               isDense: true,
@@ -147,6 +146,7 @@ class ManuscriptEditPage extends StatelessWidget {
                 return TextField(
                   cursorColor: Colors.black45,
                   controller: controller,
+                  autofocus: autofocus,
                   keyboardType: TextInputType.multiline,
                   textInputAction: TextInputAction.newline,
                   maxLines: null,
@@ -316,12 +316,14 @@ class ManuscriptEditPage extends StatelessWidget {
     );
   }
 
-  Widget _editStateMenu() {
+  Widget _editStateMenu(BuildContext context) {
     return Row(
       children: [
-        RippleIconButton(
-          Icons.share,
-          onPressed: () => Share.share(_edit.title + "\n\n" + _edit.content),
+        Builder(
+          builder: (context) => RippleIconButton(
+            Icons.share,
+            onPressed: () => _share(context),
+          ),
         ),
         RippleIconButton(
           Icons.delete_outline,
@@ -414,6 +416,16 @@ class ManuscriptEditPage extends StatelessWidget {
         ),
         const SizedBox(width: 8),
       ],
+    );
+  }
+
+  Future<void> _share(BuildContext context) async {
+    final box = context.findRenderObject() as RenderBox;
+    await SharePlus.instance.share(
+      ShareParams(
+        text: '${_edit.title}\n\n${_edit.content}',
+        sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size,
+      ),
     );
   }
 


### PR DESCRIPTION
## 概要

Prescの新規原稿入力位置とiOS共有エクスポートを修正しました。

## 変更内容

- 新規原稿作成時の初期フォーカスをタイトル欄から本文欄へ変更
- `Share.share`を`SharePlus.instance.share`へ移行
- 共有ボタンの画面上の位置を`sharePositionOrigin`として渡し、iPadを含むiOSで共有シートを表示できるよう修正

## 確認結果

- Flutter 3.47の対象ファイル解析でエラーなし
- GitHub Actions上の`flutter test`成功
- GitHub Actions上の未署名iOS releaseビルド成功（Runner.app 65.0MB）
- `share_plus` 11.0.0のiPad向け要件に従い、共有元座標を設定

## 既知のCI課題

- 署名archiveは既存のiOS Distribution証明書とRunner／Share ExtensionのProvisioning Profileが2025年10月9日に失効しているため失敗
- 証明書とProvisioning Profileを更新後、iOS CIを再実行してDeployGate配布を確認する必要あり

## CI

https://github.com/sakusaku3939/Presc/actions/runs/32981762622
